### PR TITLE
Added $GOPATH/bin to $PATH

### DIFF
--- a/golang.el
+++ b/golang.el
@@ -2,6 +2,8 @@
 (setq go-bin-path (string-join `(,go-path "/bin")))
 
 (setenv "GOPATH" go-path)
+(setenv "PATH" (concat (getenv "PATH") ":" go-bin-path))
+
 (add-to-list 'exec-path go-bin-path)
 
 (when (memq window-system '(mac ns))


### PR DESCRIPTION
Now go-mode and Golang config in general not depends of start Emacs from a
console that have this env var set.